### PR TITLE
Make WebAppViewController.webViewContainer public; bump version

### DIFF
--- a/HIPWebApp/Info.plist
+++ b/HIPWebApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/HIPWebApp/WebAppViewController.swift
+++ b/HIPWebApp/WebAppViewController.swift
@@ -52,7 +52,7 @@ public class WebAppViewController: UIViewController, WKScriptMessageHandler {
     private var _webViewMessageHandling: WebAppMessageHandling? { return webApp as? WebAppMessageHandling }
 
     /// The web view will be added as a subview of this, sharing its constraints. Defaults to `self.view`.
-    @IBOutlet private var webViewContainer: UIView?
+    @IBOutlet public var webViewContainer: UIView?
 
     /// WebApp creates the navigation delegate, but we store it here so that every WebApp doesn't have to remember
     /// to do so (it's a weak ref on the web view).

--- a/Readme.md
+++ b/Readme.md
@@ -100,6 +100,14 @@ protocols are related.
 
 ## Release history
 
+### 1.0.2
+
+Made `WebAppViewController.webViewContainer` public
+
+### 1.0.1
+
+Update to Swift 2.3
+
 ### 1.0
 
 Initial release.


### PR DESCRIPTION
This ought to have been public at release. Simple oversight.